### PR TITLE
fix: for ore generation

### DIFF
--- a/src/main/java/org/terasology/customOreGen/PocketStructureDefinition.java
+++ b/src/main/java/org/terasology/customOreGen/PocketStructureDefinition.java
@@ -167,9 +167,9 @@ public class PocketStructureDefinition extends AbstractMultiChunkStructureDefini
             minNoisyR2 *= minNoisyR2;
             // iterate through blocks
             Vector4f pos = new Vector4f();
-            for (int x = Math.max(0, minPosition.x()); x <= Math.min(chunkSize.x() - 1, maxPosition.x()); x++) {
-                for (int y = Math.max(0, minPosition.y()); y <= Math.min(chunkSize.y() - 1, maxPosition.y()); y++) {
-                    for (int z = Math.max(0, minPosition.z()); z <= Math.min(chunkSize.z() - 1, maxPosition.z()); z++) {
+            for (int x =  minPosition.x(); x <=  maxPosition.x(); x++) {
+                for (int y =  minPosition.y(); y <= maxPosition.y(); y++) {
+                    for (int z = minPosition.z(); z <= maxPosition.z(); z++) {
                         if (!callback.canReplace(x, y, z)) {
                             continue;
                         }
@@ -178,7 +178,10 @@ public class PocketStructureDefinition extends AbstractMultiChunkStructureDefini
                         pos.x = x + 0.5F;
                         pos.y = y + 0.5F;
                         pos.z = z + 0.5F;
+                        pos.w = 1.0f;
                         invMat.transform(pos);
+                        pos.w = 0.0f;
+
                         // check radius
                         float r2 = pos.lengthSquared();
                         if (r2 > maxNoisyR2) {

--- a/src/main/java/org/terasology/customOreGen/PocketStructureDefinition.java
+++ b/src/main/java/org/terasology/customOreGen/PocketStructureDefinition.java
@@ -22,6 +22,7 @@ import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.joml.Vector4f;
+import org.terasology.joml.geom.AABBf;
 import org.terasology.utilities.procedural.Noise3D;
 import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.random.Random;
@@ -116,9 +117,12 @@ public class PocketStructureDefinition extends AbstractMultiChunkStructureDefini
             if (rMax < 0) {
                 rMax = 0;
             }
-            Vector3f min = new Vector3f();
-            Vector3f max = new Vector3f();
-            transform.scale(rMax).frustumAabb(min, max);
+
+            AABBf aabb = new AABBf(-rMax, -rMax, -rMax, rMax, rMax, rMax);
+            aabb.transform(transform);
+
+            Vector3f min = new Vector3f(aabb.minX, aabb.minY, aabb.minZ);
+            Vector3f max = new Vector3f(aabb.maxX, aabb.maxY, aabb.maxZ);
 
             minPosition = new Vector3i(Math.roundUsing(min.x, RoundingMode.FLOOR), Math.roundUsing(min.y, RoundingMode.FLOOR), Math.roundUsing(min.z, RoundingMode.FLOOR));
             maxPosition = new Vector3i(Math.roundUsing(max.x + 1, RoundingMode.FLOOR), Math.roundUsing(max.y + 1, RoundingMode.FLOOR), Math.roundUsing(max.z + 1, RoundingMode.FLOOR));


### PR DESCRIPTION
This addresses the AABB bounds but I'm not so sure about the translation on line 78. I don't think that is a actually a translation. multiplying. for generating structures it expects the transformed location to be a local transform relative to the chunk from what I can tell. 

```
m00 * x + m10 * y + m20 * z = m30
m01 * x + m11 * y + m21 * z = m31
m02 * x + m12 * y + m22 * z = m32
m03 * x + m13 * y + m23 * z = m33
```

Fixes https://github.com/MovingBlocks/Terasology/issues/4523